### PR TITLE
footer-link outline none

### DIFF
--- a/src/sass/components/_footer.scss
+++ b/src/sass/components/_footer.scss
@@ -161,6 +161,7 @@ width: 400px;
    display: flex;
     justify-content: center;
     align-items: center;
+    outline: none;
 transform: scale(1);
   
     @include animation(transform);


### PR DESCRIPTION
додала для footer-link  властивість outline none, щоб на іконках при фокусі не з'являлась чорна рамка